### PR TITLE
[Feature] Add one-click test runner scripts for API and UI tests

### DIFF
--- a/run_api.bat
+++ b/run_api.bat
@@ -1,0 +1,19 @@
+@echo off
+REM One-click API test runner
+set REPORT_DIR=.\Reports\api-results
+set OUTPUT_DIR=.\Reports\api-report
+
+echo === Running API Tests ===
+pytest API_Automation/cases -v --alluredir="%REPORT_DIR%"
+if errorlevel 1 goto :error
+
+echo === Generating Allure Report ===
+allure generate "%REPORT_DIR%" -o "%OUTPUT_DIR%" --clean
+allure open "%OUTPUT_DIR%"
+goto :end
+
+:error
+echo Tests failed.
+exit /b 1
+
+:end

--- a/run_api.sh
+++ b/run_api.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# One-click API test runner
+set -e
+
+REPORT_DIR="./Reports/api-results"
+OUTPUT_DIR="./Reports/api-report"
+
+echo "=== Running API Tests ==="
+pytest API_Automation/cases -v --alluredir="$REPORT_DIR"
+
+echo "=== Generating Allure Report ==="
+allure generate "$REPORT_DIR" -o "$OUTPUT_DIR" --clean
+allure open "$OUTPUT_DIR"

--- a/run_ui.bat
+++ b/run_ui.bat
@@ -1,0 +1,21 @@
+@echo off
+REM One-click UI test runner (requires Appium + device/simulator)
+set REPORT_DIR=.\Reports\ui-results
+set OUTPUT_DIR=.\Reports\ui-report
+
+echo === Starting Appium Server ===
+start /b appium
+timeout /t 3 /nobreak >nul
+
+echo === Running UI Tests ===
+pytest UI_Automation/Tests -v -n 0 --alluredir="%REPORT_DIR%"
+set EXIT_CODE=%errorlevel%
+
+echo === Stopping Appium Server ===
+taskkill /f /im node.exe >nul 2>&1
+
+echo === Generating Allure Report ===
+allure generate "%REPORT_DIR%" -o "%OUTPUT_DIR%" --clean
+allure open "%OUTPUT_DIR%"
+
+exit /b %EXIT_CODE%

--- a/run_ui.sh
+++ b/run_ui.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# One-click UI test runner (requires Appium + device/simulator)
+set -e
+
+REPORT_DIR="./Reports/ui-results"
+OUTPUT_DIR="./Reports/ui-report"
+
+echo "=== Starting Appium Server ==="
+appium &
+APPIUM_PID=$!
+sleep 3
+
+echo "=== Running UI Tests ==="
+pytest UI_Automation/Tests -v -n 0 --alluredir="$REPORT_DIR"
+EXIT_CODE=$?
+
+echo "=== Stopping Appium Server ==="
+kill $APPIUM_PID
+
+echo "=== Generating Allure Report ==="
+allure generate "$REPORT_DIR" -o "$OUTPUT_DIR" --clean
+allure open "$OUTPUT_DIR"
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Add shell and batch scripts to run API/UI tests with a single command.

## Changes

- `run_api.sh` / `run_api.bat` — run API tests and open Allure report
- `run_ui.sh` / `run_ui.bat` — start Appium, run UI tests (serial), stop Appium, open Allure report

## Test Plan

- [x] Run `./run_api.sh` and verify API tests execute and report opens
- [x] Run `./run_ui.sh` and verify Appium starts, tests run, Appium stops

Closes #17