### PR TITLE
[CI] Split test reporting into separate workflow for fork PR support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   api-test:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
       - uses: actions/checkout@v4
 
@@ -30,18 +28,16 @@ jobs:
             --junitxml=./Reports/junit-api.xml
         continue-on-error: true
 
-      - name: 上传测试报告
+      - name: 上传 allure 结果
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: allure-results
           path: Reports/api-results/
 
-      - name: 发布 JUnit 结果
-        uses: dorny/test-reporter@v1
+      - name: 上传 JUnit 结果
+        uses: actions/upload-artifact@v4
         if: always()
-        continue-on-error: true
         with:
-          name: API Test Results
+          name: junit-results
           path: Reports/junit-api.xml
-          reporter: java-junit

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,26 @@
+name: Publish Test Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: 下载 JUnit 结果
+        uses: actions/download-artifact@v4
+        with:
+          name: junit-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 发布 JUnit 结果
+        uses: dorny/test-reporter@v1
+        with:
+          name: API Test Results
+          path: junit-api.xml
+          reporter: java-junit


### PR DESCRIPTION
Closes #20

将 `dorny/test-reporter` 从 ci.yml 拆分到独立的 report.yml，通过 `workflow_run` 触发，解决 fork PR 无法获得 `checks: write` 权限的问题。