### PR TITLE
[Feature] Stabilize MeteorTest API suite runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,11 @@ A platform or Local Agent should read `meteortest.yml` at the repository root, s
 Example:
 
 ```bash
-python -m pytest API_Automation/cases -v --alluredir=Reports/platform/local-demo-001/allure-results
+python -m pytest API_Automation/cases -v -n 0 --alluredir=Reports/platform/local-demo-001/allure-results
 python -m pytest UI_Automation/Tests -v -n 0 --alluredir=Reports/platform/local-demo-001/allure-results
 ```
+
+Platform-triggered API suites use `-n 0` to run serially. The project-level `pytest.ini` enables `pytest-xdist` with `-n auto` for normal local runs, but serial execution is more stable for Windows Local Agent runs and avoids temporary-directory permission failures.
 
 Platform-triggered runs should write artifacts under:
 
@@ -238,6 +240,16 @@ Reports/platform/{task_id}/
 ```
 
 The tested `.ipa` or `.app` should be passed by the platform task as `app_path` or `app_url`. This repository does not build the app and does not own general-purpose task scheduling.
+
+API smoke suites require `API_BASE_URL` to point to the target service. Without it, the API integration tests are collected successfully but skipped intentionally. When it is set, it overrides the `api.base_url` value from `config/environments.yaml`:
+
+```powershell
+$env:TEST_ENV="staging"
+$env:API_BASE_URL="https://your-staging-api.example.com"
+.venv\Scripts\python.exe -m pytest API_Automation\cases -v -n 0 -m smoke
+```
+
+For MeteorTest Local Agent runs, set `API_BASE_URL` in the same shell before starting the Agent so the suite subprocess inherits it.
 
 ## Local Demo Console
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,9 +223,11 @@ locust -f locustfile.py --host=https://api-dev.yunlu.com
 示例：
 
 ```bash
-python -m pytest API_Automation/cases -v --alluredir=Reports/platform/local-demo-001/allure-results
+python -m pytest API_Automation/cases -v -n 0 --alluredir=Reports/platform/local-demo-001/allure-results
 python -m pytest UI_Automation/Tests -v -n 0 --alluredir=Reports/platform/local-demo-001/allure-results
 ```
+
+平台触发的 API suites 使用 `-n 0` 串行运行。项目级 `pytest.ini` 为普通本地运行启用了 `pytest-xdist` 的 `-n auto`，但串行执行对 Windows Local Agent 更稳定，可以避免临时目录权限失败。
 
 平台触发运行建议统一写入：
 
@@ -238,6 +240,16 @@ Reports/platform/{task_id}/
 ```
 
 被测 `.ipa` 或 `.app` 应由平台任务以 `app_path` 或 `app_url` 传入。本仓库不负责构建 App，也不负责通用任务调度。
+
+API smoke suites 需要通过 `API_BASE_URL` 指向目标服务。如果没有设置该变量，API 集成测试会正常收集，但会被有意跳过。设置后，它会覆盖 `config/environments.yaml` 里的 `api.base_url`：
+
+```powershell
+$env:TEST_ENV="staging"
+$env:API_BASE_URL="https://your-staging-api.example.com"
+.venv\Scripts\python.exe -m pytest API_Automation\cases -v -n 0 -m smoke
+```
+
+如果通过 MeteorTest Local Agent 运行，需要在启动 Agent 的同一个 shell 中设置 `API_BASE_URL`，这样 suite 子进程才能继承这个变量。
 
 ## 本地 Demo 控制台
 

--- a/conftest.py
+++ b/conftest.py
@@ -34,7 +34,7 @@ def env_config():
 @pytest.fixture(scope="session")
 def api_base_url(env_config):
     """API 基础 URL"""
-    return env_config["api"]["base_url"]
+    return os.getenv("API_BASE_URL") or env_config["api"]["base_url"]
 
 
 @pytest.fixture(scope="session")
@@ -153,7 +153,7 @@ def allure_environment(env_config):
     env_properties = {
         "Python版本": sys.version.split()[0],
         "测试环境": env_config.get("name", "dev"),
-        "API地址": env_config.get("api", {}).get("base_url", ""),
+        "API地址": os.getenv("API_BASE_URL") or env_config.get("api", {}).get("base_url", ""),
         "生成时间": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "测试框架": "pytest + Appium + Allure",
     }

--- a/meteortest.yml
+++ b/meteortest.yml
@@ -39,7 +39,7 @@ suites:
   - id: api_smoke
     name: API smoke tests
     type: api
-    command: python -m pytest API_Automation/cases -v -m smoke --alluredir=Reports/platform/{task_id}/allure-results
+    command: python -m pytest API_Automation/cases -v -n 0 -m smoke --alluredir=Reports/platform/{task_id}/allure-results
     report:
       allure: true
     outputs:
@@ -48,7 +48,7 @@ suites:
   - id: api_all
     name: API full regression
     type: api
-    command: python -m pytest API_Automation/cases -v --alluredir=Reports/platform/{task_id}/allure-results
+    command: python -m pytest API_Automation/cases -v -n 0 --alluredir=Reports/platform/{task_id}/allure-results
     report:
       allure: true
     outputs:

--- a/tests/test_api_base_url_config.py
+++ b/tests/test_api_base_url_config.py
@@ -1,0 +1,22 @@
+import os
+
+import pytest
+
+from conftest import api_base_url
+
+
+def test_api_base_url_uses_environment_override(monkeypatch):
+    monkeypatch.setenv("API_BASE_URL", "https://override.example.test")
+
+    value = api_base_url.__wrapped__({"api": {"base_url": "https://yaml.example.test"}})
+
+    assert value == "https://override.example.test"
+
+
+def test_api_base_url_falls_back_to_environment_yaml(monkeypatch):
+    monkeypatch.delenv("API_BASE_URL", raising=False)
+
+    value = api_base_url.__wrapped__({"api": {"base_url": "https://yaml.example.test"}})
+
+    assert value == "https://yaml.example.test"
+


### PR DESCRIPTION
## Summary
Stabilize the MeteorTest-triggered API suite path for Windows Local Agent runs and make API_BASE_URL the runtime override for API tests.

## Proposed Changes
- Add -n 0 to platform-triggered API suites in meteortest.yml for serial Local Agent execution.
- Let API_BASE_URL override config/environments.yaml api.base_url for actual requests and Allure environment metadata.
- Add regression tests for API_BASE_URL override and YAML fallback behavior.
- Update bilingual README platform integration instructions.

## Test Plan
- .venv\Scripts\python.exe -m pytest tests\test_api_base_url_config.py -q -p no:cacheprovider
- .venv\Scripts\python.exe -m pytest API_Automation\cases -v -n 0 -m smoke -rs --alluredir=Reports\platform\direct-api-smoke-venv\allure-results -p no:cacheprovider

Closes #27